### PR TITLE
rss_idx quick fix for error message for intercept

### DIFF
--- a/R/sgdi_lm.R
+++ b/R/sgdi_lm.R
@@ -51,7 +51,13 @@ sgdi_lm = function(formula, data, gamma_0=1, alpha=0.667, burn=1, inference="rs"
   mt <- attr(mf, "terms")
   y <- model.response(mf, "numeric")
   x <- model.matrix(mt, mf)[,-1]
-  rss_idx_r = rss_idx + 1   # Index starting with 1 in R and with 0 in C
+  if (inference == "rss"){
+    if (0 %in% rss_idx ){
+      stop("rss_idx includes 0 (the intercept term), where it should be bigger than 1.")
+    }
+    rss_idx_r = rss_idx + 1   # Index starting with 1 in R and with 0 in C    
+  }
+
 
   if (studentize){
     # Compute column means and standard errors and save them for later reconversion

--- a/R/sgdi_qr.R
+++ b/R/sgdi_qr.R
@@ -49,7 +49,12 @@ sgdi_qr = function(formula, data, gamma_0=1, alpha=0.667, burn=1, inference="rs"
   mt <- attr(mf, "terms")
   y <- model.response(mf, "numeric")
   x <- model.matrix(mt, mf)[,-1]
-  rss_idx_r = rss_idx + 1   # Index starting with 1 in R and with 0 in C  
+  if (inference == "rss"){
+    if (0 %in% rss_idx ){
+      stop("rss_idx includes 0 (the intercept term), where it should be bigger than 1.")
+    }
+    rss_idx_r = rss_idx + 1   # Index starting with 1 in R and with 0 in C    
+  }
   
   if (studentize){
     # Compute column means and standard errors and save them for later reconversion

--- a/tests/testthat/test-sgdi_lm.R
+++ b/tests/testthat/test-sgdi_lm.R
@@ -30,8 +30,20 @@ test_that("sgdi_lm vs. sgd_lm", {
   x = matrix(rnorm(n*(p-1)), n, (p-1))
   y = cbind(1,x) %*% bt0 + rnorm(n)
   my.dat = data.frame(y=y, x=x)
-  out1 = sgd_lm(y~., data=my.dat, )
-  out2 = sgdi_lm(y~., data=my.dat, )
+  out1 = sgd_lm(y~., data=my.dat)
+  out2 = sgdi_lm(y~., data=my.dat)
   check = max(abs(out1$coefficient - out2$coefficient))
   expect_true(check==0)
 })
+
+test_that("Stop when rss_idx includes 0 with inference=rss", 
+  {
+    n = 1e05
+    p = 5
+    bt0 = rep(5,p)
+    x = matrix(rnorm(n*(p-1)), n, (p-1))
+    y = cbind(1,x) %*% bt0 + rnorm(n)
+    my.dat = data.frame(y=y, x=x)
+    expect_error(sgdi_lm(y~., data=my.dat, inference="rss", rss_idx=c(0,1)))
+  }
+)

--- a/tests/testthat/test-sgdi_qr.R
+++ b/tests/testthat/test-sgdi_qr.R
@@ -25,3 +25,15 @@ test_that("sgdi_qr vs. sgd_qr", {
   expect_true(check==0)
 })
 
+
+test_that("Stop when rss_idx includes 0 with inference=rss", 
+          {
+            n = 1e05
+            p = 5
+            bt0 = rep(5,p)
+            x = matrix(rnorm(n*(p-1)), n, (p-1))
+            y = cbind(1,x) %*% bt0 + rnorm(n)
+            my.dat = data.frame(y=y, x=x)
+            expect_error(sgdi_qr(y~., data=my.dat, inference="rss", rss_idx=c(0,1)))
+          }
+)


### PR DESCRIPTION
Now, it gives an error message and stop when rss_idx includes 0. Some testthat shows expected results. 